### PR TITLE
Pass env to check blocks or #call methods

### DIFF
--- a/lib/health_bit.rb
+++ b/lib/health_bit.rb
@@ -60,9 +60,9 @@ module HealthBit
   end
 
   # @return [nil, CheckError]
-  def check
+  def check(env)
     checks.each do |check|
-      (exception = check.call).nil? ? next : (return exception)
+      (exception = check.call(env)).nil? ? next : (return exception)
     end
 
     nil
@@ -73,8 +73,8 @@ module HealthBit
       format = this.show_backtrace ? CheckError::FORMAT_FULL : CheckError::FORMAT_SHORT
 
       Rack::Builder.new do
-        run ->(_env) do
-          if (error = this.check)
+        run ->(env) do
+          if (error = this.check(env))
             [this.fail_code, this.headers, [error.to_s(format)]]
           else
             [this.success_code, this.headers, [this.success_text]]

--- a/lib/health_bit/check.rb
+++ b/lib/health_bit/check.rb
@@ -11,8 +11,11 @@ module HealthBit
 
     # @return [nil] if its ok
     # @return [CheckError] if not
-    def call
-      raise('The check has returned a negative value') unless handler.call
+    def call(env = {})
+      arity = handler.is_a?(Proc) ? handler.arity : handler.method(:call).arity
+      return if arity == 1 ? handler.call(env) : handler.call
+
+      raise('The check has returned a negative value')
     rescue Exception => e # rubocop:disable Lint/RescueException
       CheckError.new(name, exception: e)
     end

--- a/spec/health_bit/integration_spec.rb
+++ b/spec/health_bit/integration_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe HealthBit do
     described_class.clone
   end
 
+  let(:app3) do
+    described_class.clone
+  end
+
   before do
     # just initialize instance variable
     # inside a donor
@@ -31,6 +35,15 @@ RSpec.describe HealthBit do
     end
   end
 
+  before do
+    app3.headers = { 'app3' => 1 }
+    app3.success_code = 200
+    app3.fail_code = 500
+    app3.add('app3') do |env|
+      env["FOO"] == "BAR"
+    end
+  end
+
   context 'when app1' do
     it 'passes' do
       status, headers, content = app1.rack.call({})
@@ -48,6 +61,16 @@ RSpec.describe HealthBit do
       expect(status).to eq(503)
       expect(headers).to eq('app2' => 2)
       expect(content).to contain_exactly("Check <app2> failed")
+    end
+  end
+
+  context 'when app3' do
+    it 'passes' do
+      status, headers, content = app3.rack.call({ 'FOO' => 'BAR' })
+
+      expect(status).to eq(200)
+      expect(headers).to eq('app3' => 1)
+      expect(content).to contain_exactly('1 checks passed 🎉')
     end
   end
 end


### PR DESCRIPTION
I want to set up a healthbit check to ensure that the client IP is getting forwarded correctly through load balancers and nginx, so that `request.remote_ip` is not the internal IP of a server. I need access to the rack env to do this.

Here's how I'm using it (with the [ipaddress gem](https://github.com/ipaddress-gem/ipaddress)):

```
HealthBit.add('Public IP') do |env|
  request = ActionDispatch::Request.new(env)
  remote_ip = IPAddress request.remote_ip
  !(remote_ip.private? || remote_ip.multicast? || remote_ip.loopback? || remote_ip.link_local?)
end
```

This change is backwards compatible: It only passes env if the block or method accepts an argument.
